### PR TITLE
Make it compatible with PHP 8.1

### DIFF
--- a/src/ReverseRegex/Generator/Node.php
+++ b/src/ReverseRegex/Generator/Node.php
@@ -2,6 +2,7 @@
 namespace ReverseRegex\Generator;
 
 use \ArrayObject;
+use \Closure;
 use \SplObjectStorage;
 use \ArrayAccess;
 use \Countable;
@@ -125,7 +126,7 @@ class Node implements ArrayAccess, Countable, Iterator
      *  Apply a closure to all relations
      *
      *  @access public
-     *  @param Closer the function to apply
+     *  @param Closure $function the function to apply
      */
     public function map(Closure $function)
     {
@@ -133,60 +134,60 @@ class Node implements ArrayAccess, Countable, Iterator
             $function($node);
         }
     }
-    
+
     //------------------------------------------------------------------
     # Countable
-    
-    public function count()
+
+    public function count(): int
     {
         return count($this->links);
     }
-    
+
     //------------------------------------------------------------------
     # Iterator
 
-    public function current()
+    public function current(): mixed
     {
         return $this->links->current();
     }
-    public function key()
+    public function key(): mixed
     {
         return $this->links->key();
     }
-    public function next()
+    public function next(): void
     {
-        return $this->links->next();
+        $this->links->next();
     }
-    public function rewind()
+    public function rewind(): void
     {
-        return $this->links->rewind();
+        $this->links->rewind();
     }
-    public function valid()
+    public function valid(): bool
     {
         return $this->links->valid();
     }
-    
+
     //------------------------------------------------------------------
     # ArrayAccess Implementation
 
-    public function offsetGet($key)
+    public function offsetGet($key): mixed
     {
         return $this->attrs->offsetGet($key);
     }
 
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->attrs->offsetSet($key, $value);
     }
 
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return $this->attrs->offsetExists($key);
     }
 
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
-        return $this->attrs->offsetUnset($key);
+        $this->attrs->offsetUnset($key);
     }
 }
 

--- a/src/ReverseRegex/Generator/Node.php
+++ b/src/ReverseRegex/Generator/Node.php
@@ -146,11 +146,13 @@ class Node implements ArrayAccess, Countable, Iterator
     //------------------------------------------------------------------
     # Iterator
 
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return $this->links->current();
     }
-    public function key(): mixed
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         return $this->links->key();
     }
@@ -170,7 +172,8 @@ class Node implements ArrayAccess, Countable, Iterator
     //------------------------------------------------------------------
     # ArrayAccess Implementation
 
-    public function offsetGet($key): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($key)
     {
         return $this->attrs->offsetGet($key);
     }


### PR DESCRIPTION
Including the type hints can be done since PHP 7.0. The deprecation warning started with PHP 8.1, see https://php.watch/versions/8.1/internal-method-return-types

Without this change, with PHP 8.1 or later you get these kinds of errors:

`Fatal error: During inheritance of ArrayAccess:
Uncaught TYPO3\CMS\Core\Error\Exception: PHP Runtime Deprecation Notice:
Return type of ReverseRegex\Generator\Node::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/ilario-pierbattista/reverse-regex/src/ReverseRegex/Generator/Node.php line 173`