### PR TITLE
Fix issue #13: Allow SimpleRandom to handle unbounded quantifiers (* …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Composer scripts: `cs-check`, `cs-fix`, `phpstan`, `phpstan-baseline`
 - GitHub Actions workflows for code style and static analysis (PHP 8.1-8.4)
 - PHPStan baseline for incremental code quality improvements
-
+### Fixed
+- Allow SimpleRandom to handle unbounded quantifiers (#13)
 ### Removed
 - Support for PHP 7.4 and 8.0 (minimum required version is now PHP 8.1)
+
 ## [0.5.0] - 2024-12-07
 ### Added
 - Compatibility with PHP 8.2, 8.3, 8.4

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,16 @@ run-php-8.3:
 .PHONY: run-php-8.4
 run-php-8.4:
 	docker compose run --remove-orphans php84 sh
+
+DK:=docker compose run --rm php81
+.PHONY: setup cs-fix test phpstan phpstan-update-baseline
+setup:
+	$(DK) composer install
+test:
+	$(DK) composer test
+cs-fix:
+	$(DK) composer cs-fix
+phpstan:
+	$(DK) composer phpstan
+phpstan-update-baseline:
+	$(DK) composer phpstan-baseline

--- a/src/ReverseRegex/Random/SimpleRandom.php
+++ b/src/ReverseRegex/Random/SimpleRandom.php
@@ -2,8 +2,6 @@
 
 namespace ReverseRegex\Random;
 
-use ReverseRegex\Exception as ReverseRegexException;
-
 /**
  *  Simple Random.
  *

--- a/src/ReverseRegex/Random/SimpleRandom.php
+++ b/src/ReverseRegex/Random/SimpleRandom.php
@@ -96,8 +96,10 @@ class SimpleRandom implements GeneratorInterface
             $max = 2_796_203;
         }
 
+        // Cap extremely large values (e.g., PHP_INT_MAX from unbounded quantifiers like * or +)
+        // to a reasonable maximum to prevent memory exhaustion
         if ($max > 2_796_203) {
-            throw new ReverseRegexException('Max param has exceeded the maxium 2796203');
+            $max = 2_796_203;
         }
 
         if ($this->seed == 0) {

--- a/src/ReverseRegex/Test/ParserTest.php
+++ b/src/ReverseRegex/Test/ParserTest.php
@@ -7,6 +7,7 @@ use ReverseRegex\Generator\Scope;
 use ReverseRegex\Lexer;
 use ReverseRegex\Parser;
 use ReverseRegex\Random\MersenneRandom;
+use ReverseRegex\Random\SimpleRandom;
 
 class ParserTest extends Basic
 {
@@ -237,6 +238,36 @@ class ParserTest extends Basic
         $this->expectExceptionMessage("Error found STARTING at position 16 after `\(0[23478]\)[9-4]` with msg Character class range 9 - 4 is out of order");
 
         $generator = $parser->parse()->getResult();
+    }
+
+    public function testSimpleRandomWithStarQuantifier(): void
+    {
+        $lexer = new Lexer('[a-z]*');
+        $container = new Scope();
+        $head = new Scope();
+        $parser = new Parser($lexer, $container, $head);
+        $generator = $parser->parse()->getResult();
+
+        $result = '';
+        $random = new SimpleRandom(777);
+
+        $generator->generate($result, $random);
+        $this->assertMatchesRegularExpression('/^[a-z]*$/', $result);
+    }
+
+    public function testSimpleRandomWithPlusQuantifier(): void
+    {
+        $lexer = new Lexer('[a-z]+');
+        $container = new Scope();
+        $head = new Scope();
+        $parser = new Parser($lexer, $container, $head);
+        $generator = $parser->parse()->getResult();
+
+        $result = '';
+        $random = new SimpleRandom(777);
+
+        $generator->generate($result, $random);
+        $this->assertMatchesRegularExpression('/^[a-z]+$/', $result);
     }
 }
 // End of File


### PR DESCRIPTION
…and +)

Instead of throwing an exception when max exceeds the SimpleRandom limit of 2,796,203, the generator now caps the value to a reasonable maximum. This prevents crashes when patterns with * or + quantifiers are used, as these set max to PHP_INT_MAX.

The fix maintains backward compatibility by silently capping the value rather than throwing an exception, allowing code that uses SimpleRandom to work with all quantifier types.

Fixes: #13