### PR TITLE
Prepare library for internal trust psp usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: PHP unit
+name: Tests
 
 on:
   push:
@@ -11,35 +11,26 @@ permissions:
 
 jobs:
   test:
-
-    name: Tests (PHP ${{ matrix.php }})
+    name: Tests (PHP 8.5)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: ["8.1", "8.2", "8.3", "8.4"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Setup PHP with PECL extension
-        uses: shivammathur/setup-php@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: "8.5"
+          coverage: none
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-lock
 
       - name: Install dependencies
-        run: composer install
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Audit dependencies
+        run: composer audit
 
       - name: Run test suite
-        run: vendor/bin/phpunit
+        run: composer test

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -11,32 +11,23 @@ permissions:
 
 jobs:
   code-style:
-
-    name: Code Style (PHP 8.1)
+    name: Code Style (PHP 8.5)
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Setup PHP with PECL extension
-        uses: shivammathur/setup-php@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: "8.1"
+          php-version: "8.5"
+          coverage: none
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-8.1-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-8.1-
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-lock
 
       - name: Install dependencies
-        run: composer install
+        run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Run PHP CS Fixer (check)
         run: composer cs-check

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -30,4 +30,4 @@ jobs:
         run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Run PHP CS Fixer (check)
-        run: composer cs-check
+        run: composer lint

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["8.1", "8.2", "8.3", "8.4"]
+        php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,37 +12,23 @@ permissions:
 
 jobs:
   phpstan:
-
-    name: PHPStan (PHP ${{ matrix.php }})
+    name: PHPStan (PHP 8.5)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Setup PHP with PECL extension
-        uses: shivammathur/setup-php@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: "8.5"
+          coverage: none
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: >-
-            ${{ runner.os }}-php-${{ matrix.php }}-${{
-            hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-lock
 
       - name: Install dependencies
-        run: composer install
+        run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Run PHPStan
         run: composer phpstan

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -31,4 +31,4 @@ jobs:
         run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Run PHPStan
-        run: composer phpstan
+        run: composer stan

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -17,12 +17,7 @@ $config->setRules($rulesProvider->getRules());
 $config->setRiskyAllowed(true);
 
 $finder = new PhpCsFixer\Finder();
-
-/*
- * You can set manually these paths:
- */
-$autoloadPathProvider = new Facile\CodingStandards\AutoloadPathProvider();
-$finder->in([...$autoloadPathProvider->getPaths(), 'examples']);
+$finder->in(__DIR__ . '/src/Trust');
 
 $config->setFinder($finder);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0] - 2026-06-09
+
+### Added
+- Added `Trust\ReverseRegex` as the sole public API for generating strings from supported regex patterns.
+- Added focused tests for secure random generation, regex conformance, output limits, and public exception types.
+- Added PHP 8.5 Docker Compose and Makefile commands for local development.
+- Added dependency auditing to CI.
+
+### Changed
+- Renamed the Composer package to `trust-psp/reverse-regex`.
+- Raised the minimum supported PHP version from 8.1 to 8.5.
+- Marked the legacy `ReverseRegex` and `PHPStats` APIs as internal implementation details.
+- Changed generation to use PHP's cryptographically secure `random_int()` source.
+- Changed invalid or unsupported patterns to throw `InvalidArgumentException`.
+- Updated Composer scripts to `lint`, `lint:fix`, `stan`, and `stan:baseline`.
+- Updated PHPUnit, PHPStan, code-style configuration, documentation, and development tooling for the maintained `Trust` API.
+- Updated GitHub Actions workflows to run on PHP 8.5 and pinned third-party actions to immutable commit SHAs.
+
+### Security
+- Limited generated values to a maximum of 40 characters.
+- Rejects patterns whose maximum possible output exceeds 40 characters, including unbounded `*` and `+` quantifiers.
+- Added a post-generation length check as a secondary safeguard.
+
+### Fixed
+- Replaced deprecated `SplObjectStorage::attach()` and `detach()` calls for PHP 8.5 compatibility.
+
 ## [0.6.0] - 2026-03-31
 ### Added
 - Code quality tools: Facile.it coding standard and PHPStan 2 (level 5)
@@ -43,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See https://github.com/icomefromthenet/ReverseRegex
 
-[Unreleased]: https://github.com/ilario-pierbattista/ReverseRegex/compare/0.6.0..HEAD
+[Unreleased]: https://github.com/trust-psp/reverse-regex/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/trust-psp/reverse-regex/releases/tag/v1.0.0
 [0.6.0]: https://github.com/ilario-pierbattista/ReverseRegex/compare/0.5.0..0.6.0
 [0.5.0]: https://github.com/ilario-pierbattista/ReverseRegex/compare/0.4.0..0.5.0
 [0.4.0]: https://github.com/ilario-pierbattista/ReverseRegex/compare/0.3.1..0.4.0

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,41 @@
-.PHONY: run-php-8.1
-run-php-8.1:
-	docker compose run --remove-orphans php81 sh
+up start:
+	docker compose up -d
 
-.PHONY: run-php-8.2
-run-php-8.2:
-	docker compose run --remove-orphans php82 sh
+down:
+	docker compose down
 
-.PHONY: run-php-8.3
-run-php-8.3:
-	docker compose run --remove-orphans php83 sh
+restart re:
+	make stop
+	make start
 
-.PHONY: run-php-8.4
-run-php-8.4:
-	docker compose run --remove-orphans php84 sh
+shell enter:
+	docker compose exec reverse-regex bash
 
-DK:=docker compose run --rm php81
-.PHONY: setup cs-fix test phpstan phpstan-update-baseline
-setup:
-	$(DK) composer install
+log logs:
+	docker-compose logs reverse-regex
+
+tail follow:
+	docker-compose logs --follow reverse-regex
+
+composer-install:
+	docker compose exec reverse-regex composer install
+
+composer-dump:
+	docker compose exec reverse-regex composer dump-autoload -o
+
+lint:
+	docker compose exec reverse-regex composer lint
+
+lint-fix:
+	docker compose exec reverse-regex composer lint:fix
+
+stan:
+	docker compose exec reverse-regex composer stan
+
 test:
-	$(DK) composer test
-cs-fix:
-	$(DK) composer cs-fix
-phpstan:
-	$(DK) composer phpstan
-phpstan-update-baseline:
-	$(DK) composer phpstan-baseline
+	docker compose exec reverse-regex composer test
+
+all:
+	docker compose exec reverse-regex composer lint
+	docker compose exec reverse-regex composer stan
+	docker compose exec reverse-regex composer test

--- a/README.md
+++ b/README.md
@@ -1,94 +1,47 @@
-ReverseRegex
-============
+# ReverseRegex
 
-[![PHP unit](https://github.com/ilario-pierbattista/ReverseRegex/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/ilario-pierbattista/ReverseRegex/actions/workflows/ci.yaml)
+[![Tests](https://github.com/trust-psp/reverse-regex/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/trust-psp/reverse-regex/actions/workflows/ci.yaml)
 
-> This is a fork of https://github.com/ilario-pierbattista/ReverseRegex which is fork of https://github.com/icomefromthenet/ReverseRegex
-> These libraries are very old, `ilario-pierbattista/ReverseRegex` is not maintained since 2020, so it was forked to avoid original library deprecation.
+Generate strings matching a supported regular-expression pattern.
 
-Use Regular Expressions to generate text strings can be used in the following situations:
+This package requires PHP 8.5 or newer. It is a maintained wrapper around the
+legacy `ilario-pierbattista/reverse-regex` implementation.
 
-1. Writing test data for web forms.
-2. Writing test data for databases.
-3. Generating test data for regular expressions. 
+## Installation
 
-## Example (simplified for Trust PSP)
+```shell
+composer require trust-psp/reverse-regex
+```
+
+## Usage
+
+`Trust\ReverseRegex` is the only public API. Classes in the `ReverseRegex` and
+`PHPStats` namespaces are internal implementation details.
 
 ```php
 use Trust\ReverseRegex;
 
-public function __construct(private ReverseRegex $regex)
-{
-}
-
-public fucntion example(): void
-{
-    // Results `TA2C3D4E5F`
-    $example = $this->regex->generate('/^T[2345679ACDEFGHJKLMNPQRSTUVWXYZ]{9}$/');
-    ...
-}
-``` 
-
-
-## Example (original)
-
-```php
-
-use ReverseRegex\Lexer;
-use ReverseRegex\Random\SimpleRandom;
-use ReverseRegex\Parser;
-use ReverseRegex\Generator\Scope;
-
-# load composer
-require "vendor/autoload.php";
-
-$lexer = new  Lexer('[a-z]{10}');
-$gen   = new SimpleRandom(10007);
-$result = '';
-
-$parser = new Parser($lexer,new Scope(),new Scope());
-$parser->parse()->getResult()->generate($result,$gen);
-
-echo $result;
-
+$generator = new ReverseRegex();
+$identifier = $generator->generate('T[2345679ACDEFGHJKLMNPQRSTUVWXYZ]{9}');
 ```
 
-***Produces***
+Patterns must not include delimiters such as `/.../`. Generated values are
+limited to 40 characters. Patterns that can exceed this limit, including `*`
+and `+` quantifiers, throw `LengthException`. Invalid or unsupported patterns
+throw `InvalidArgumentException`.
 
-```
-jmceohykoa
-aclohnotga
-jqegzuklcv
-ixdbpbgpkl
-kcyrxqqfyw
-jcxsjrtrqb
-kvaczmawlz
-itwrowxfxh
-auinmymonl
-dujyzuhoag
-vaygybwkfm
-```
-#### Other examples
+Generation uses PHP's cryptographically secure `random_int()`. Randomness alone
+does not guarantee uniqueness, so persisted identifiers must also have a unique
+database constraint and collision retry.
 
-1. [Australian phone numbers](https://github.com/ilario-pierbattista/ReverseRegex/blob/master/examples/ausphone.php)
-2. [Australian postcodes](https://github.com/ilario-pierbattista/ReverseRegex/blob/master/examples/auspostcode.php)
-3. [Mobile numbers](https://github.com/ilario-pierbattista/ReverseRegex/blob/master/examples/mobilenumbers.php)
+## Writing A Regex
 
-
-##Installing
-
-To install use composer
-
-    composer require ilario-pierbattista/reverse-regex
-
-## Writing a Regex
-
-1. Escape all meta-characters i.e. if you need to escape the character in a regex you will need to escape here.
-2. Not all meta-characters are suppported see list below.
-3. Use `\X{####}` to specify unicode value use `[\X{####}-\X{####}]` to specify range.
-4. Unicdoe `\p` not supported, I could not find a port of [UCD](http://www.unicode.org/ucd/) to php, maybe in the future support be added.
-5. Quantifiers are applied to left most group, literal or character class.
-6. Beware of the `+` and `*` quantifers they apply a possible maxium number of occurances up to `PHP_INT_MAX`.
+1. Escape regex metacharacters that should be generated literally.
+2. Not all regex features are supported; see the table below.
+3. Use `\X{####}` for Unicode values and `[\X{####}-\X{####}]` for ranges.
+4. Unicode properties such as `\p` are not supported.
+5. Quantifiers apply to the preceding group, literal, or character class.
+6. The maximum possible generated length must not exceed 40 characters.
 
 ### Regex Support
 
@@ -155,6 +108,5 @@ To install use composer
     <td> \xFF[\xFF-\xFF] </td><td> Hex ranges</td> <td> </td>  
   </tr>
  </table>
-
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ ReverseRegex
 
 [![PHP unit](https://github.com/ilario-pierbattista/ReverseRegex/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/ilario-pierbattista/ReverseRegex/actions/workflows/ci.yaml)
 
-> This is a fork of https://github.com/icomefromthenet/ReverseRegex (that provides `icomefromthenet/reverse-regex`).
+> This is a fork of https://github.com/ilario-pierbattista/ReverseRegex which is fork of https://github.com/icomefromthenet/ReverseRegex
+> These libraries are very old, `ilario-pierbattista/ReverseRegex` is not maintained since 2020, so it was forked to avoid original library deprecation.
 
 Use Regular Expressions to generate text strings can be used in the following situations:
 
@@ -11,8 +12,25 @@ Use Regular Expressions to generate text strings can be used in the following si
 2. Writing test data for databases.
 3. Generating test data for regular expressions. 
 
+## Example (simplified for Trust PSP)
 
-##Example
+```php
+use Trust\ReverseRegex;
+
+public function __construct(private ReverseRegex $regex)
+{
+}
+
+public fucntion example(): void
+{
+    // Results `TA2C3D4E5F`
+    $example = $this->regex->generate('/^T[2345679ACDEFGHJKLMNPQRSTUVWXYZ]{9}$/');
+    ...
+}
+``` 
+
+
+## Example (original)
 
 ```php
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "test data",
     "generator"
   ],
-  "homepage": "https://github.com/ilario-pierbattista/ReverseRegex",
+  "homepage": "https://github.com/trust-psp/reverse-regex",
   "type": "library",
   "license": "MIT",
   "authors": [
@@ -19,8 +19,8 @@
   ],
   "require-dev": {
     "phpunit/phpunit": "^9",
-    "facile-it/facile-coding-standard": "1.3.1",
-    "friendsofphp/php-cs-fixer": "3.88.2",
+    "facile-it/facile-coding-standard": "^1.5",
+    "friendsofphp/php-cs-fixer": "^3.95.4",
     "phpstan/phpstan": "^2.0"
   },
   "require": {
@@ -37,10 +37,7 @@
     }
   },
   "scripts": {
-    "test": [
-      "composer install",
-      "vendor/bin/phpunit"
-    ],
+    "test": "vendor/bin/phpunit",
     "cs-fix": "php-cs-fixer fix --diff",
     "cs-check": "php-cs-fixer fix --dry-run --diff",
     "phpstan": "vendor/bin/phpstan analyse",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ilario-pierbattista/reverse-regex",
+  "name": "trust-psp/reverse-regex",
   "description": "Convert Regular Expressions into text, for testing. Fork of icomefromthenet/reverse-regex",
   "keywords": [
     "regex",
@@ -24,7 +24,7 @@
     "phpstan/phpstan": "^2.0"
   },
   "require": {
-    "php": "^8.1",
+    "php": "^8.5",
     "doctrine/lexer": "^1.2.1 || ^2",
     "doctrine/collections": "^1.6.5",
     "symfony/polyfill-mbstring": "^1.20.0"
@@ -32,7 +32,8 @@
   "autoload": {
     "psr-0": {
       "ReverseRegex": "src/",
-      "PHPStats": "src/"
+      "PHPStats": "src/",
+      "Trust": "src/"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,16 @@
       "name": "Lewis Dyer",
       "email": "getintouch@icomefromthenet.com",
       "homepage": "http://www.icomefromthenet.com"
+    },
+    {
+      "name": "Trust PSP",
+      "email": "info@psptrust.com",
+      "homepage": "https://sptrust.com"
+    },
+    {
+      "name": "Vitalij Vladimirov",
+      "email": "vitalij@psptrust.com",
+      "homepage": "https://cto4sale.com"
     }
   ],
   "require-dev": {
@@ -38,10 +48,10 @@
   },
   "scripts": {
     "test": "vendor/bin/phpunit",
-    "cs-fix": "php-cs-fixer fix --diff",
-    "cs-check": "php-cs-fixer fix --dry-run --diff",
-    "phpstan": "vendor/bin/phpstan analyse",
-    "phpstan-baseline": "vendor/bin/phpstan analyse --generate-baseline"
+    "lint:fix": "php-cs-fixer fix --diff",
+    "lint": "php-cs-fixer fix --dry-run --diff",
+    "stan": "vendor/bin/phpstan analyse",
+    "stan:baseline": "vendor/bin/phpstan analyse --generate-baseline"
   },
   "conflict": {
     "icomefromthenet/reverse-regex": "*"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,30 +1,17 @@
 services:
-  php81: &common
-    build: &build
-      dockerfile: php.Dockerfile
-      context: .docker
-      args:
-        - BASE=php:8.1-cli-alpine
+  reverse-regex:
+    image: ghcr.io/trust-psp/base-php-local:8.5
     tty: true
+    user: ${UID:-1000}
+    restart: "no"
     volumes:
-      - .:/usr/app
-    user: "1000:1000"
-    working_dir: /usr/app
-  php82:
-    <<: *common
-    build:
-      <<: *build
-      args:
-        - BASE=php:8.2-cli-alpine
-  php83:
-    <<: *common
-    build:
-      <<: *build
-      args:
-        - BASE=php:8.3-cli-alpine
-  php84:
-    <<: *common
-    build:
-      <<: *build
-      args:
-        - BASE=php:8.4-cli-alpine
+      - .:/app:rw
+    working_dir: /app
+    command: >
+      sh -c "
+        php /build/scripts/LoadGithubAuth.php &&
+        php /build/scripts/LoadGitHooks.php &&
+        php /usr/bin/composer install &&
+        tail -f /dev/null
+      "
+    container_name: ${CONTAINER_NAME:-reverse-regex}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,12 +1,7 @@
 parameters:
     level: 5
-    phpVersion: 80100 # PHP 8.1.0 - minimum supported version
+    phpVersion: 80500
     paths:
-        - src
+        - src/Trust
     excludePaths:
-        - src/ReverseRegex/Test
-        - src/PHPStats/Generator
-    reportUnmatchedIgnoredErrors: false
-
-includes:
-    - phpstan-baseline.neon
+        - src/Trust/Test

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
      <testsuites>
          <testsuite name="UnitTests For ReverseRegex">
             <directory>./src/ReverseRegex/Test/</directory>
+            <directory>./src/Trust/Test/</directory>
         </testsuite>
   </testsuites>  
     

--- a/src/PHPStats/Generator/GeneratorInterface.php
+++ b/src/PHPStats/Generator/GeneratorInterface.php
@@ -4,6 +4,8 @@ namespace PHPStats\Generator;
 
 /**
  *  Interface that all generators should implement.
+ *
+ * @internal
  */
 interface GeneratorInterface
 {

--- a/src/ReverseRegex/ArrayCollection.php
+++ b/src/ReverseRegex/ArrayCollection.php
@@ -4,6 +4,9 @@ namespace ReverseRegex;
 
 use Doctrine\Common\Collections\ArrayCollection as BaseCollection;
 
+/**
+ * @internal
+ */
 class ArrayCollection extends BaseCollection
 {
     /**

--- a/src/ReverseRegex/Exception.php
+++ b/src/ReverseRegex/Exception.php
@@ -8,6 +8,8 @@ namespace ReverseRegex;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class Exception extends \Exception {}
 // End of File

--- a/src/ReverseRegex/Generator/AlternateInterface.php
+++ b/src/ReverseRegex/Generator/AlternateInterface.php
@@ -8,6 +8,8 @@ namespace ReverseRegex\Generator;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 interface AlternateInterface
 {

--- a/src/ReverseRegex/Generator/ContextInterface.php
+++ b/src/ReverseRegex/Generator/ContextInterface.php
@@ -10,6 +10,8 @@ use PHPStats\Generator\GeneratorInterface;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 interface ContextInterface
 {

--- a/src/ReverseRegex/Generator/LiteralScope.php
+++ b/src/ReverseRegex/Generator/LiteralScope.php
@@ -12,6 +12,8 @@ use ReverseRegex\Exception as GeneratorException;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class LiteralScope extends Scope
 {

--- a/src/ReverseRegex/Generator/Node.php
+++ b/src/ReverseRegex/Generator/Node.php
@@ -15,6 +15,8 @@ use SplObjectStorage;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class Node implements ArrayAccess, Countable, Iterator
 {
@@ -79,7 +81,7 @@ class Node implements ArrayAccess, Countable, Iterator
      */
     public function &attach(self $node)
     {
-        $this->links->attach($node);
+        $this->links->offsetSet($node);
 
         return $this;
     }
@@ -95,7 +97,7 @@ class Node implements ArrayAccess, Countable, Iterator
     {
         foreach ($this->links as $linked_node) {
             if ($linked_node == $node) {
-                $this->links->detach($node);
+                $this->links->offsetUnset($node);
             }
         }
 

--- a/src/ReverseRegex/Generator/RepeatInterface.php
+++ b/src/ReverseRegex/Generator/RepeatInterface.php
@@ -8,6 +8,8 @@ namespace ReverseRegex\Generator;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 interface RepeatInterface
 {

--- a/src/ReverseRegex/Generator/Scope.php
+++ b/src/ReverseRegex/Generator/Scope.php
@@ -11,6 +11,8 @@ use ReverseRegex\Exception as GeneratorException;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class Scope extends Node implements ContextInterface, RepeatInterface, AlternateInterface
 {

--- a/src/ReverseRegex/Lexer.php
+++ b/src/ReverseRegex/Lexer.php
@@ -11,6 +11,8 @@ use ReverseRegex\Exception as LexerException;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class Lexer extends AbstractLexer
 {

--- a/src/ReverseRegex/Parser.php
+++ b/src/ReverseRegex/Parser.php
@@ -13,6 +13,8 @@ use ReverseRegex\Parser\StrategyInterface;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class Parser
 {

--- a/src/ReverseRegex/Parser/CharacterClass.php
+++ b/src/ReverseRegex/Parser/CharacterClass.php
@@ -12,6 +12,8 @@ use ReverseRegex\Lexer;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class CharacterClass implements StrategyInterface
 {

--- a/src/ReverseRegex/Parser/Quantifier.php
+++ b/src/ReverseRegex/Parser/Quantifier.php
@@ -12,6 +12,8 @@ use ReverseRegex\Lexer;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class Quantifier implements StrategyInterface
 {

--- a/src/ReverseRegex/Parser/Short.php
+++ b/src/ReverseRegex/Parser/Short.php
@@ -11,6 +11,8 @@ use ReverseRegex\Lexer;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class Short implements StrategyInterface
 {

--- a/src/ReverseRegex/Parser/StrategyInterface.php
+++ b/src/ReverseRegex/Parser/StrategyInterface.php
@@ -11,6 +11,8 @@ use ReverseRegex\Lexer;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 interface StrategyInterface
 {

--- a/src/ReverseRegex/Parser/Unicode.php
+++ b/src/ReverseRegex/Parser/Unicode.php
@@ -12,6 +12,8 @@ use ReverseRegex\Lexer;
  *  @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *  @since 0.0.1
+ *
+ * @internal
  */
 class Unicode implements StrategyInterface
 {

--- a/src/ReverseRegex/Random/GeneratorFactory.php
+++ b/src/ReverseRegex/Random/GeneratorFactory.php
@@ -8,6 +8,8 @@ use ReverseRegex\Exception as ReverseRegexException;
  *   Generator Factory.
  *
  *   @author Lewis Dyer <getintouch@icomefromthenet.com>
+ *
+ * @internal
  */
 class GeneratorFactory
 {

--- a/src/ReverseRegex/Random/GeneratorInterface.php
+++ b/src/ReverseRegex/Random/GeneratorInterface.php
@@ -6,6 +6,8 @@ use PHPStats\Generator\GeneratorInterface as CommonInterface;
 
 /**
  *  Interface that all generators should implement.
+ *
+ * @internal
  */
 interface GeneratorInterface extends CommonInterface
 {

--- a/src/ReverseRegex/Random/MersenneRandom.php
+++ b/src/ReverseRegex/Random/MersenneRandom.php
@@ -8,6 +8,8 @@ namespace ReverseRegex\Random;
  *   @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
  *   @see http://boxrefuge.com/?tag=random-number
+ *
+ * @internal
  */
 class MersenneRandom implements GeneratorInterface
 {

--- a/src/ReverseRegex/Random/SimpleRandom.php
+++ b/src/ReverseRegex/Random/SimpleRandom.php
@@ -8,6 +8,8 @@ namespace ReverseRegex\Random;
  *  @see http://www.sitepoint.com/php-random-number-generator/
  *
  *  @author Craig Buckler
+ *
+ * @internal
  */
 class SimpleRandom implements GeneratorInterface
 {

--- a/src/ReverseRegex/Random/SrandRandom.php
+++ b/src/ReverseRegex/Random/SrandRandom.php
@@ -12,6 +12,7 @@ namespace ReverseRegex\Random;
  *
  * @author Lewis Dyer <getintouch@icomefromthenet.com>
  *
+ * @internal
  */
 class SrandRandom implements GeneratorInterface
 {

--- a/src/Trust/ReverseRegex.php
+++ b/src/Trust/ReverseRegex.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trust;
+
+use ReverseRegex\Exception;
+use ReverseRegex\Generator\Scope;
+use ReverseRegex\Lexer;
+use ReverseRegex\Parser;
+use ReverseRegex\Random\SimpleRandom;
+
+/**
+ * Trust PSP helper to simplify string generation from regex.
+ */
+final class ReverseRegex
+{
+    /**
+     * @throws Exception
+     */
+    public function generate(string $regex): string
+    {
+        $result = null;
+
+        $parser = new Parser(
+            new  Lexer($regex),
+            new Scope(),
+            new Scope()
+        );
+
+        $parser->parse()->getResult()->generate($result, new SimpleRandom());
+
+        return $result;
+    }
+}

--- a/src/Trust/ReverseRegex.php
+++ b/src/Trust/ReverseRegex.php
@@ -4,32 +4,119 @@ declare(strict_types=1);
 
 namespace Trust;
 
+use PHPStats\Generator\GeneratorInterface;
 use ReverseRegex\Exception;
+use ReverseRegex\Generator\LiteralScope;
 use ReverseRegex\Generator\Scope;
 use ReverseRegex\Lexer;
 use ReverseRegex\Parser;
-use ReverseRegex\Random\SimpleRandom;
 
 /**
  * Trust PSP helper to simplify string generation from regex.
  */
 final class ReverseRegex
 {
+    private const int MAX_RESULT_LENGTH = 40;
+
     /**
      * @throws Exception
      */
     public function generate(string $regex): string
     {
-        $result = null;
+        $result = '';
 
         $parser = new Parser(
-            new  Lexer($regex),
+            new Lexer($regex),
             new Scope(),
             new Scope()
         );
 
-        $parser->parse()->getResult()->generate($result, new SimpleRandom());
+        $scope = $parser->parse()->getResult();
+        $this->validateRegexScope($scope);
+
+        $result = $scope->generate($result, $this->secureRandomGenerator());
+        $this->validateResult($result);
 
         return $result;
+    }
+
+    private function validateRegexScope(Scope $scope): void
+    {
+        if ($this->maximumLength($scope) > self::MAX_RESULT_LENGTH) {
+            throw new Exception(\sprintf(
+                'Generated value cannot exceed %d characters',
+                self::MAX_RESULT_LENGTH
+            ));
+        }
+    }
+
+    private function validateResult(string $result): void
+    {
+        if (mb_strlen($result) > self::MAX_RESULT_LENGTH) {
+            throw new Exception(\sprintf(
+                'Generated value cannot exceed %d characters',
+                self::MAX_RESULT_LENGTH
+            ));
+        }
+    }
+
+    private function maximumLength(Scope $scope): int
+    {
+        $contentLength = $this->getContentLength($scope);
+        $repetitions = max($scope->getMinOccurances(), $scope->getMaxOccurances());
+
+        if ($contentLength === 0 || $repetitions === 0) {
+            return 0;
+        }
+
+        if ($repetitions > intdiv(self::MAX_RESULT_LENGTH, $contentLength)) {
+            return self::MAX_RESULT_LENGTH + 1;
+        }
+
+        return $contentLength * $repetitions;
+    }
+
+    private function getContentLength(Scope $scope): int
+    {
+        if ($scope instanceof LiteralScope) {
+            return 1;
+        }
+
+        $contentLength = 0;
+        
+        if ($scope->usingAlternatingStrategy() === true) {
+            foreach ($scope as $child) {
+                $contentLength = max($contentLength, $this->maximumLength($child));
+            }
+            
+            return $contentLength;
+        }
+        
+        foreach ($scope as $child) {
+            $contentLength += $this->maximumLength($child);
+
+            if ($contentLength > self::MAX_RESULT_LENGTH) {
+                return self::MAX_RESULT_LENGTH + 1;
+            }
+        }
+        
+        return $contentLength;
+    }
+
+    private function secureRandomGenerator(): GeneratorInterface
+    {
+        return new class implements GeneratorInterface {
+            public function generate($min = 0, $max = null): int
+            {
+                return random_int((int) $min, (int) ($max ?? PHP_INT_MAX));
+            }
+
+            public function seed($seed = null): void {}
+
+            public function max(): float
+            {
+                return (float) PHP_INT_MAX;
+            }
+        };
     }
 }

--- a/src/Trust/ReverseRegex.php
+++ b/src/Trust/ReverseRegex.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Trust;
 
 use PHPStats\Generator\GeneratorInterface;
-use ReverseRegex\Exception;
+use InvalidArgumentException;
+use LengthException;
+use ReverseRegex\Exception as LegacyException;
 use ReverseRegex\Generator\LiteralScope;
 use ReverseRegex\Generator\Scope;
 use ReverseRegex\Lexer;
@@ -19,33 +21,38 @@ final class ReverseRegex
     private const int MAX_RESULT_LENGTH = 40;
 
     /**
-     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws LengthException
      */
     public function generate(string $regex): string
     {
-        $result = '';
+        try {
+            $result = '';
 
-        $parser = new Parser(
-            new Lexer($regex),
-            new Scope(),
-            new Scope()
-        );
+            $parser = new Parser(
+                new Lexer($regex),
+                new Scope(),
+                new Scope(),
+            );
 
-        $scope = $parser->parse()->getResult();
-        $this->validateRegexScope($scope);
+            $scope = $parser->parse()->getResult();
+            $this->validateRegexScope($scope);
 
-        $result = $scope->generate($result, $this->secureRandomGenerator());
-        $this->validateResult($result);
+            $result = $scope->generate($result, $this->secureRandomGenerator());
+            $this->validateResult($result);
 
-        return $result;
+            return $result;
+        } catch (LegacyException $exception) {
+            throw new InvalidArgumentException($exception->getMessage(), 0, $exception);
+        }
     }
 
     private function validateRegexScope(Scope $scope): void
     {
         if ($this->maximumLength($scope) > self::MAX_RESULT_LENGTH) {
-            throw new Exception(\sprintf(
+            throw new LengthException(\sprintf(
                 'Generated value cannot exceed %d characters',
-                self::MAX_RESULT_LENGTH
+                self::MAX_RESULT_LENGTH,
             ));
         }
     }
@@ -53,9 +60,9 @@ final class ReverseRegex
     private function validateResult(string $result): void
     {
         if (mb_strlen($result) > self::MAX_RESULT_LENGTH) {
-            throw new Exception(\sprintf(
+            throw new LengthException(\sprintf(
                 'Generated value cannot exceed %d characters',
-                self::MAX_RESULT_LENGTH
+                self::MAX_RESULT_LENGTH,
             ));
         }
     }
@@ -83,15 +90,15 @@ final class ReverseRegex
         }
 
         $contentLength = 0;
-        
+
         if ($scope->usingAlternatingStrategy() === true) {
             foreach ($scope as $child) {
                 $contentLength = max($contentLength, $this->maximumLength($child));
             }
-            
+
             return $contentLength;
         }
-        
+
         foreach ($scope as $child) {
             $contentLength += $this->maximumLength($child);
 
@@ -99,7 +106,7 @@ final class ReverseRegex
                 return self::MAX_RESULT_LENGTH + 1;
             }
         }
-        
+
         return $contentLength;
     }
 
@@ -108,14 +115,14 @@ final class ReverseRegex
         return new class implements GeneratorInterface {
             public function generate($min = 0, $max = null): int
             {
-                return random_int((int) $min, (int) ($max ?? PHP_INT_MAX));
+                return random_int((int) $min, (int) ($max ?? \PHP_INT_MAX));
             }
 
             public function seed($seed = null): void {}
 
             public function max(): float
             {
-                return (float) PHP_INT_MAX;
+                return (float) \PHP_INT_MAX;
             }
         };
     }

--- a/src/Trust/Test/ReverseRegexTest.php
+++ b/src/Trust/Test/ReverseRegexTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trust\Test;
+
+use PHPUnit\Framework\TestCase;
+use ReverseRegex\Exception;
+use Trust\ReverseRegex;
+
+final class ReverseRegexTest extends TestCase
+{
+    public function testGeneratesDifferentMatchingValuesForTheSameRegex(): void
+    {
+        $generator = new ReverseRegex();
+        $values = [];
+
+        for ($i = 0; $i < 20; ++$i) {
+            $value = $generator->generate('[a-z]{20}');
+
+            self::assertMatchesRegularExpression('/^[a-z]{20}$/', $value);
+            $values[$value] = true;
+        }
+
+        self::assertGreaterThan(1, \count($values));
+    }
+
+    public function testAllowsAResultOfExactlyFortyCharacters(): void
+    {
+        $value = new ReverseRegex()->generate('[a-z]{40}');
+
+        self::assertSame(40, mb_strlen($value));
+        self::assertMatchesRegularExpression('/^[a-z]{40}$/', $value);
+    }
+
+    /**
+     * @dataProvider oversizedRegexProvider
+     */
+    public function testRejectsRegexThatCanGenerateMoreThanFortyCharacters(string $regex): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Generated value cannot exceed 40 characters');
+
+        new ReverseRegex()->generate($regex);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function oversizedRegexProvider(): iterable
+    {
+        yield 'fixed quantifier' => ['a{41}'];
+        yield 'nested quantifiers' => ['(ab{20}){2}'];
+        yield 'unbounded star' => ['a*'];
+        yield 'unbounded plus' => ['a+'];
+        yield 'oversized alternative' => ['a|b{41}'];
+    }
+}

--- a/src/Trust/Test/ReverseRegexTest.php
+++ b/src/Trust/Test/ReverseRegexTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Trust\Test;
 
+use InvalidArgumentException;
+use LengthException;
 use PHPUnit\Framework\TestCase;
-use ReverseRegex\Exception;
 use Trust\ReverseRegex;
 
 final class ReverseRegexTest extends TestCase
@@ -38,10 +39,17 @@ final class ReverseRegexTest extends TestCase
      */
     public function testRejectsRegexThatCanGenerateMoreThanFortyCharacters(string $regex): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(LengthException::class);
         $this->expectExceptionMessage('Generated value cannot exceed 40 characters');
 
         new ReverseRegex()->generate($regex);
+    }
+
+    public function testDoesNotExposeLegacyExceptions(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ReverseRegex()->generate('[z-a]');
     }
 
     /**


### PR DESCRIPTION
### Added
- Added `Trust\ReverseRegex` as the sole public API for generating strings from supported regex patterns.
- Added focused tests for secure random generation, regex conformance, output limits, and public exception types.
- Added PHP 8.5 Docker Compose and Makefile commands for local development.
- Added dependency auditing to CI.

### Changed
- Renamed the Composer package to `trust-psp/reverse-regex`.
- Raised the minimum supported PHP version from 8.1 to 8.5.
- Marked the legacy `ReverseRegex` and `PHPStats` APIs as internal implementation details.
- Changed generation to use PHP's cryptographically secure `random_int()` source.
- Changed invalid or unsupported patterns to throw `InvalidArgumentException`.
- Updated Composer scripts to `lint`, `lint:fix`, `stan`, and `stan:baseline`.
- Updated PHPUnit, PHPStan, code-style configuration, documentation, and development tooling for the maintained `Trust` API.
- Updated GitHub Actions workflows to run on PHP 8.5 and pinned third-party actions to immutable commit SHAs.

### Security
- Limited generated values to a maximum of 40 characters.
- Rejects patterns whose maximum possible output exceeds 40 characters, including unbounded `*` and `+` quantifiers.
- Added a post-generation length check as a secondary safeguard.

### Fixed
- Replaced deprecated `SplObjectStorage::attach()` and `detach()` calls for PHP 8.5 compatibility.